### PR TITLE
This is a series of key/values, not an array

### DIFF
--- a/Potion Limiter/vanillapotions.json
+++ b/Potion Limiter/vanillapotions.json
@@ -1,4 +1,4 @@
-[
+{
     "potion_skooma_01":{
         "name":"Skooma",
         "duration":60
@@ -1055,4 +1055,4 @@
         "name":"Nord Mead",
         "duration":60
     }
-]
+}


### PR DESCRIPTION
When using cjson, which more strictly follows the json spec, the below
error is shown on server startup:

[2019-05-26 13:28:16] [ERR]: [Script]: Could not load custom/vanillapotions.json using Lua CJSON due to improperly formatted JSON! Error:
../lua/CoreScripts/lib/lua/jsonInterface.lua:62: Expected comma or array end but found T_COLON at character 25
custom/vanillapotions.json is being read via the slower dkjson
instead.

This commit fixes that by replacing the outer brackets with curly braces.